### PR TITLE
Fix font path to resolve from theme directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Add the following frontmatter to your `slides.md`. Start Slidev then it will pro
 theme: <b>excali-slide</b>
 ---</code></pre>
 
+
 Learn more about [how to use a theme](https://sli.dev/guide/theme-addon#use-theme).
 
 ## Contributing

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,7 +1,7 @@
 @font-face {
 	font-family: 'Virgil';
 	src: local("Virgil"),
-    url("/fonts/Virgil.woff2") format("woff");
+    url("../fonts/Virgil.woff2") format("woff");
 }
 
 :root {

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,7 +1,7 @@
 @font-face {
 	font-family: 'Virgil';
 	src: local("Virgil"),
-    url("../fonts/Virgil.woff2") format("woff");
+    url("../fonts/Virgil.woff2") format("woff2");
 }
 
 :root {


### PR DESCRIPTION
## Summary
- Changed Virgil font URL from absolute (`/fonts/Virgil.woff2`) to relative (`../fonts/Virgil.woff2`) so it resolves from the theme's own directory instead of the user's public folder.

Fixes #3